### PR TITLE
build: Support a fallback to java 8 if java 7 is not found

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -2406,7 +2406,8 @@ function set_java_home() {
                 export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
                 ;;
         esac
-      else
+      fi
+      if [ ! "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]; then
         case `uname -s` in
             Darwin)
                 export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)


### PR DESCRIPTION
 * In the case of a host installed only with java 8,
    the build starts correctly but on use of JAVA_HOME
    binaries, the java references are missing

 * Allow the java 7 to be tested and try to use java 8

Change-Id: Ie50892edb54feb8608a0ef80a1c2a8667703e8ee