### PR TITLE
envsetup: Fix cafremote/aospremote for projects with non-standard paths

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1710,7 +1710,7 @@ function aospremote()
         return 1
     fi
     git remote rm aosp 2> /dev/null
-    PROJECT=$(pwd -P | sed "s#$ANDROID_BUILD_TOP\/##")
+    PROJECT=$(pwd -P | sed -e "s#$ANDROID_BUILD_TOP\/##; s#-caf.*##; s#\/default##")
     if (echo $PROJECT | grep -qv "^device")
     then
         PFX="platform/"
@@ -1727,7 +1727,7 @@ function cafremote()
         return 1
     fi
     git remote rm caf 2> /dev/null
-    PROJECT=$(pwd -P | sed "s#$ANDROID_BUILD_TOP\/##")
+    PROJECT=$(pwd -P | sed -e "s#$ANDROID_BUILD_TOP\/##; s#-caf.*##; s#\/default##")
     if (echo $PROJECT | grep -qv "^device")
     then
         PFX="platform/"


### PR DESCRIPTION
* Fix -caf and -caf-<platform> projects
* Fix AOSP HALs that are synced in "/default" subfolder

Change-Id: I33cc344a3234de6698676c32035622acbec03dd1