### PR TITLE
build: always copy recovery.img to BOOTABLE_IMAGES.

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1998,9 +1998,7 @@ endif # BOARD_USES_RECOVERY_AS_BOOT
 	@# Prebuilt boot images
 	$(hide) mkdir -p $(zip_root)/BOOTABLE_IMAGES
 	$(hide) $(ACP) $(INSTALLED_BOOTIMAGE_TARGET) $(zip_root)/BOOTABLE_IMAGES/
-ifeq ($(BOARD_USES_FULL_RECOVERY_IMAGE),true)
 	$(hide) $(ACP) $(INSTALLED_RECOVERYIMAGE_TARGET) $(zip_root)/BOOTABLE_IMAGES/
-endif
 ifdef BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE
 	@# Contents of the vendor image
 	$(hide) $(call package_files-copy-root, \


### PR DESCRIPTION
Actually there are some devices with strange recovery image handling that don't use full recovery image,
but require recovery.img in BOOTABLE_IMAGES for proper patch generation.

Change-Id: I206ac4d477577a5264533d55d1fec24129fd0ee8