### PR TITLE
build: fix verity generation

### DIFF
--- a/tools/releasetools/build_image.py
+++ b/tools/releasetools/build_image.py
@@ -185,7 +185,7 @@ def BuildVerityMetadata(image_size, verity_metadata_path, root_hash, salt,
   if signer_args:
     cmd += " --signer_args=\"%s\"" % (' '.join(signer_args),)
   print cmd
-  runcmd = ["system/extras/verity/build_verity_metadata.py", image_size, verity_metadata_path, root_hash, salt, block_device, signer_path, key];
+  runcmd = [str(a) for a in ["system/extras/verity/build_verity_metadata.py", "build", image_size, verity_metadata_path, root_hash, salt, block_device, signer_path, key]];
   if verity_key_password is not None:
     sp = subprocess.Popen(runcmd, stdin=subprocess.PIPE)
     sp.communicate(verity_key_password)


### PR DESCRIPTION
* Now build_verity_metadata.py takes an arg telling it what to do,
  in this case "build" is our intention, so update our custom runcmd
  array.

* Ensure we cast all args to Popen as strings or picky python gets
  angry that we pass an int (image_size) to Popen

Change-Id: I71c5e45e3155f470259f91f6f1a880e780aef369